### PR TITLE
Fix setting length property to `0`

### DIFF
--- a/client/posts/array-length-0-vs-array-[]/index.tsx
+++ b/client/posts/array-length-0-vs-array-[]/index.tsx
@@ -71,7 +71,7 @@ console.log(bar);   // []
     foo = [];   // will throw an exception of 
                 // "Assignment to constant variable"
 
-    foo.length = [];
+    foo.length = 0;
     ~~~
 `}
 />


### PR DESCRIPTION
Though setting `foo.length = [];` also empties the array because it is not a numerical value I think the intention was to set it to `0`